### PR TITLE
Adds support for 'this', observers and behaviors

### DIFF
--- a/PolymerTS/polymer.ts
+++ b/PolymerTS/polymer.ts
@@ -1,144 +1,163 @@
-﻿// Type definitions for polymer v1.0
+// Type definitions for polymer v1.0
 // Project: https://github.com/polymer
 // Definitions by: Antonino Porcino <https://github.com/nippur72>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-interface Polymer 
-{
-   (prototype: PolymerElement): Function;
-   Class(prototype: PolymerElement): Function;
-   dom(node: HTMLElement): HTMLElement;
+// ref to Polymer.Base (this)
+class base {
+	$: any;
+	$$: any;
+
+	arrayDelete(path: string, item: string|any):any {}
+	async(callback: Function, waitTime?: number):any {}
+	attachedCallback():void {}
+	attributeFollows(name: string, toElement: HTMLElement, fromElement: HTMLElement):void {}
+	cancelAsync(handle: number):void {}
+	cancelDebouncer(jobName: string):void {}
+	classFollows(name: string, toElement: HTMLElement, fromElement: HTMLElement):void {}
+	create(tag: string, props: Object):any {}
+	debounce(jobName: string, callback: Function, wait?: number):void {}
+	deserialize(value: string, type: any):any {}
+	distributeContent():void {}
+	domHost():void {}
+	elementMatches(selector: string, node: Element):any {}
+	fire(type: string, detail: Object, options?: Object):any {}
+	flushDebouncer(jobName: string):void {}
+	get(path: string|Array<string|number>):any {}
+	getContentChildNodes(slctr: string):any {}
+	getContentChildren(slctr: string):any {}
+	getNativePrototype(tag: string):any {}
+	getPropertyInfo(property: string):any {}
+	importHref(href: string, onload?: Function, onerror?: Function):any {}
+	instanceTemplate(template: any):any {}
+	isDebouncerActive(jobName: string):any {}
+	linkPaths(to: string, from: string):void {}
+	listen(node: Element, eventName: string, methodName: string):void {}
+	mixin(target: Object, source: Object):void {}
+	notifyPath(path: string, value: any, fromAbove: any):void {}
+	pop(path: string):any {}
+	push(path: string, value: any):any {}
+	reflectPropertyToAttribute(name: string):void {}
+	resolveUrl(url: string):any {}
+	scopeSubtree(container: Element, shouldObserve: boolean):void {}
+	serialize(value: string):any {}
+	serializeValueToAttribute(value: any, attribute: string, node: Element):void {}
+	set(path: string, value: any, root?: Object):any {}
+	setScrollDirection(direction: string, node: HTMLElement):void {}
+	shift(path: string, value: any):any {}
+	splice(path: string, start: number, deleteCount: number):any {}
+	toggleAttribute(name: string, bool: boolean, node?: HTMLElement):void {}
+	toggleClass(name: string, bool: boolean, node?: HTMLElement):void {}
+	transform(transform: string, node?: HTMLElement):void {}
+	translate3d(x, y, z, node?: HTMLElement):void {}
+	unlinkPaths(path: string):void {}
+	unshift(path: string, value: any):any {}
+	updateStyles():void {}
+}
+
+interface Polymer {
+	(prototype: PolymerElement): Function;
+	Class(prototype: PolymerElement): Function;
+	dom(node: HTMLElement): HTMLElement;
+
+	appendChild?(node): HTMLElement;
+	insertBefore?(node, beforeNode): HTMLElement;
+	removeChild?(node): HTMLElement;
+	flush?();
+
+	// Path to the value to read. The path may be specified as a string (e.g. foo.bar.baz) or an array of path parts (e.g. ['foo.bar', 'baz']). Note that bracketed expressions are not supported; string-based path parts must be separated by dots. Note that when dereferencing array indicies, the index may be used as a dotted part directly (e.g. users.12.name or ['users', 12, 'name']). Convienence method for reading a value from a path. Note, if any part in the path is undefined, this method returns undefined (this method does not throw when dereferencing undefined paths).
+
 }
 
 declare var Polymer: Polymer;
 
-interface PolymerElement 
-{	
-   properties?: Object;
-   listeners?: Object;
+interface PolymerElement {
+	properties?: Object;
+	listeners?: Object;
+	behaviors?: Object[];
+	observers?: String[];
 
-   // lifecycle
-   factoryImpl? (): void;
-	ready? (): void;
-	created? (): void;
-	attached? (): void;
-	detached? (): void;
-	attributeChanged? (attrName: string, oldVal: any, newVal: any): void;
-	
-   $?: HTMLElement;
-
-   // utility functions
-
-   // Returns the first node in this element’s local DOM that matches selector.
-   $$?(selector): HTMLElement;   
-
-   // Toggles the named boolean class on the host element, adding the class if bool is truthy and removing it if bool is falsey. If node is specified, sets the class on node instead of the host element.
-   toggleClass?(name, bool, node?); 
-
-   // Like toggleClass, but toggles the named boolean attribute.
-   toggleAttribute?(name, bool, node?); 
-
-   // Moves a boolean attribute from oldNode to newNode, unsetting the attribute (if set) on oldNode and setting it on newNode.
-   attributeFollows?(name, newNode, oldNode); 
-
-   // Fires a custom event. The options object can contain the following properties:
-   fire?(type, detail?, options?); 
-
-   // Calls method asynchronously. If no wait time is specified, runs tasks with microtask timing (after the current method finishes, but before the next event from the event queue is processed). Returns a handle that can be used to cancel the task.
-   async?(method, wait?); 
-
-   // Cancels the identified async task.
-   cancelAsync?(handle); 
-
-   // Call debounce to collapse multiple requests for a named task into one invocation, which is made after the wait time has elapsed with no new request. If no wait time is given, the callback is called at microtask timing (guaranteed to be before paint).
-   debounce?(jobName, callback, wait?); 
-
-   // Cancels an active debouncer without calling the callback.
-   cancelDebouncer?(jobName); 
-
-   // Calls the debounced callback immediately and cancels the debouncer.
-   flushDebouncer?(jobName); 
-
-   // Returns true if the named debounce task is waiting to run.
-   isDebouncerActive?(jobName); 
-
-   // Applies a CSS transform to the specified node, or this element if no node is specified. 
-   transform?(transform, node); 
-   
-   // Transforms the specified node, or this element if no node is specified.
-   translate3d?(x, y, z, node); 
-   
-   // Dynamically imports an HTML document.
-   importHref?(href, onload, onerror); 
+	// lifecycle
+	factoryImpl?(): void;
+	ready?():void;
+	created?():void;
+	attached?():void;
+	detached?():void;
+	attributeChanged?(attrName: string, oldVal: any, newVal: any):void;
+	updateStyles?():void;
 }
 
 
 // tag decorator
-function tag(tagname: string) 
-{
-   return function (target: Function) 
-   { 
-      target.prototype["is"] = tagname;          
-   }
+function component(tagname: string) {
+	return function(target: Function) {
+		target.prototype["is"] = tagname;
+	}
 }
 
 // extends decorator
-function extendsTag(tagname: string) 
-{
-   return (target: Function) =>
-   { 
-      target.prototype["extends"] = tagname;          
-   }
+function extend(tagname: string) {
+	return (target: Function) => {
+		target.prototype["extends"] = tagname;
+	}
 }
 
 // hostAttributes decorator
-function hostAttributes(attributes: Object) 
-{
-   return (target: Function) =>
-   { 
-      target.prototype["hostAttributes"] = attributes;          
-   }
+function hostAttribute(attributes: Object) {
+	return (target: Function) => {
+		target.prototype["hostAttributes"] = attributes;
+	}
 }
 
 // property definition interface
-interface propDefinition
-{
-   type?: Function;
-   value?: boolean|number|string|Function;
-   reflectToAttribute?: boolean;
-   readonly?: boolean;
-   notify?: boolean;
-   computed?: string;
-   observer?: string;
+interface propDefinition {
+	type?: any;
+	value?: any;
+	reflectToAttribute?: boolean;
+	readonly?: boolean;
+	notify?: boolean;
+	computed?: string;
+	observer?: string;
 }
 
 // property decorator
-function property(ob: propDefinition)
-{   
-   return (target: PolymerElement, propertyKey: string) => {            
-      target.properties = target.properties || {};
-      target.properties[propertyKey] = ob;      
-   }
+function property(ob: propDefinition) {
+	return (target: PolymerElement, propertyKey: string) => {
+		target.properties = target.properties || {};
+		target.properties[propertyKey] = ob;
+	}
 }
 
 // listener decorator
-function listener(eventName: string)
-{   
-   return (target: PolymerElement, propertyKey: string) => {                  
-      target.listeners = target.listeners || {};
-      target.listeners[eventName] = propertyKey;      
-   }
+function listener(eventName: string) {
+	return (target: PolymerElement, propertyKey: string) => {
+		target.listeners = target.listeners || {};
+		target.listeners[eventName] = propertyKey;
+	}
+}
+
+// Behavior decorator
+function behavior(behaviorObject: Object) {
+	return (target: PolymerElement) => {
+		target.behaviors = target.behaviors || [];
+		target.behaviors.push(behaviorObject);
+	}
+}
+
+// Observer decorator
+function observer(observerName: string) {
+	return (target: PolymerElement) => {
+		target.observers = target.observers || [];
+		target.observers.push(observerName);
+	}
 }
 
 // element registration functions
 
-function Register(element: Function): void
-{
-   Polymer(element.prototype);
+function createElement(element: Function): void {
+	Polymer(element.prototype);
 }
 
-function RegisterClass(element: Function): void
-{
-   Polymer.Class(element.prototype);
+function createClass(element: Function): void {
+	Polymer.Class(element.prototype);
 }
-


### PR DESCRIPTION
Hey may you check this? It's based off http://polymer.github.io/polymer/. I changed the decorator tag to component and RegisterClass to createElement, now you need to extend the base class to be able to use the utility functions.

Here is a preview: (the behaviors object properties still need to be declared - I'll try to find a solution for it)
```typescript
/// <reference path="polymer.ts"/>

var testBehavior = {
	start() {
		console.info('Behavior started!');
	}
}

@component("app-main")
class main extends base implements PolymerElement {
	@property({value: "peduxe"})
	public bar: string;

	@property({value: 2015})
	public foo: number;

	@property({value: ['a', 'b', 'c']})
	public letters:string[];

	@property({type: String})
	public text: string;

	@behavior([testBehavior])

	@observer('fooChanged(foo)')
	fooChanged(e) {
		console.info(e);
	}

	ready() {
		console.info('ready');
		this.start();
	}
	change() {
		var rand:number = Math.floor(Math.random() * (0 + (this.letters.length)));
		this.set('foo', this.letters[rand]);
		this.$.content.textContent = 'Polymeeeeer';
	}
	increment() {
		this.set('foo', Number(this.text));

		this.push("letters", this.text);
		console.info('incremented');
		console.info(this.letters.length);
	}
}
createElement(main);

```