### PR TITLE
Add a few missing type definitions

### DIFF
--- a/polymer-ts.js
+++ b/polymer-ts.js
@@ -210,4 +210,3 @@ function createTemplate(definition) {
     // tells polymer the element has been created
     domModule.createdCallback();
 }
-//# sourceMappingURL=polymer-ts.js.map

--- a/polymer-ts.js
+++ b/polymer-ts.js
@@ -210,3 +210,4 @@ function createTemplate(definition) {
     // tells polymer the element has been created
     domModule.createdCallback();
 }
+//# sourceMappingURL=polymer-ts.js.map

--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -74,7 +74,6 @@ module polymer {
       attached?(): void;
       detached?(): void;
       attributeChanged?(attrName: string, oldVal: any, newVal: any): void;
-      updateStyles?(): void;
 
       // 
       prototype?: Object;

--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -8,9 +8,11 @@ module polymer {
    export class Base {
 	   $: any;
 	   $$: any;
+
 	   root:HTMLElement;
 	   shadyRoot:HTMLElement;
-	   customStyle:CSSStyleDeclaration;
+           style:CSSStyleDeclaration;
+	   customStyle:{[property:string]:string;};;
 
 	   arrayDelete(path: string, item: string|any):any {}
 	   async(callback: Function, waitTime?: number):any {}

--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -11,8 +11,8 @@ module polymer {
 
 	   root:HTMLElement;
 	   shadyRoot:HTMLElement;
-           style:CSSStyleDeclaration;
-	   customStyle:{[property:string]:string;};;
+	   style:CSSStyleDeclaration;
+	   customStyle:{[property:string]:string;};
 
 	   arrayDelete(path: string, item: string|any):any {}
 	   async(callback: Function, waitTime?: number):any {}

--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -8,6 +8,9 @@ module polymer {
    export class Base {
 	   $: any;
 	   $$: any;
+	   root:HTMLElement;
+	   shadyRoot:HTMLElement;
+	   customStyle:CSSStyleDeclaration;
 
 	   arrayDelete(path: string, item: string|any):any {}
 	   async(callback: Function, waitTime?: number):any {}
@@ -94,6 +97,7 @@ declare var Polymer: {
 	(prototype: polymer.Element): Function;
 	Class(prototype: polymer.Element): Function;
 	dom(node: HTMLElement): HTMLElement;
+	dom(node: polymer.Base): HTMLElement;
 
 	appendChild?(node): HTMLElement;
 	insertBefore?(node, beforeNode): HTMLElement;


### PR DESCRIPTION
Thank you for sharing this great library. It makes creating Polymer elements a breeze, not to mention cleanly and using strict types!

This PR aims to add missing type definitions for `polymer.Base.{root,shadyRoot,style,customStyle}`, as well as to add a definition `Polymer.dom(polymer.Base)` to support passing in e.g. a parameter `this.root`.

Perhaps there is a better way, this is just a proposed solution in trying to address issue #19.

With this change, the following statements become valid:

```
@component("my-element")
class MyElement extends polymer.Base implements polymer.Element
{
    attached() {
        let a:{[property:string]:string} = this.customStyle;
        let b:CSSStyleDeclaration = this.style;
        let c:HTMLElement = this.root;
        let d:HTMLElement = this.shadyRoot;
        let div1:HTMLDivElement = document.createElement('div');
        let div2:HTMLDivElement = document.createElement('div');
        Polymer.dom(this).appendChild(div1);
        Polymer.dom(this.root).appendChild(div2);
    }
}
```

A separate issue (please let me know if this should be a separate PR) is that there is an `updateStyles` function type declared in the `Element` interface. This function is also declared in `polymer.Base`, which I suspect is the proper place. If this makes sense, this PR removes the definition from `Element`.