### PR TITLE
Correct type cast

### DIFF
--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -240,7 +240,7 @@ module polymer {
 
       domModule.innerHTML = html;
             
-      (domModule as any).createdCallback();
+      (<any> domModule).createdCallback();
    }   
 
    /*


### PR DESCRIPTION
The TypeScript 1.5 compiler complains about the following typecast:
```
(domModule as any).createdCallback();
```
This pull request simply replaces the cast with the TS compliant:
```
(<any> domModule).createdCallback();
```