### PR TITLE
Fix type signature of PolymerBase.splice to accept varargs.

### DIFF
--- a/polymer-ts.d.ts
+++ b/polymer-ts.d.ts
@@ -45,7 +45,7 @@ declare module polymer {
         set(path: string, value: any, root?: Object): any;
         setScrollDirection(direction: string, node: HTMLElement): void;
         shift(path: string, value: any): any;
-        splice(path: string, start: number, deleteCount: number): any;
+        splice(path: string, start: number, deleteCount: number, ...items: any[]): any;
         toggleAttribute(name: string, bool: boolean, node?: HTMLElement): void;
         toggleClass(name: string, bool: boolean, node?: HTMLElement): void;
         transform(transform: string, node?: HTMLElement): void;


### PR DESCRIPTION
It's not entirely clear in the polymer 1.0 docs, but the splice method is supposed to take a variable number of arguments at the end to be spliced in to the array in question, just like `Array.splice` does (see [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)).