### PR TITLE
fixed polymer properties copy if undefined

### DIFF
--- a/polymer-ts.js
+++ b/polymer-ts.js
@@ -40,15 +40,34 @@ var polymer;
         if (elementClass.prototype.is === undefined) {
             var proto = elementClass.prototype;
             var instance = new elementClass();
+            if (!instance.is) {
+                throw new Error("no name for " + elementClass);
+            }
             proto.is = instance.is;
-            proto.extends = instance.extends;
-            proto.properties = instance.properties;
-            proto.listeners = instance.listeners;
-            proto.observers = instance.observers;
-            proto.behaviors = instance.behaviors;
-            proto.hostAttributes = instance.hostAttributes;
-            proto.style = instance.style;
-            proto.template = instance.template;
+            if (instance.extends) {
+                proto.extends = instance.extends;
+            }
+            if (instance.properties) {
+                proto.properties = instance.properties;
+            }
+            if (instance.listeners) {
+                proto.listeners = instance.listeners;
+            }
+            if (instance.observers) {
+                proto.observers = instance.observers;
+            }
+            if (instance.behaviors) {
+                proto.behaviors = instance.behaviors;
+            }
+            if (instance.hostAttributes) {
+                proto.hostAttributes = instance.hostAttributes;
+            }
+            if (instance.style) {
+                proto.style = instance.style;
+            }
+            if (instance.template) {
+                proto.template = instance.template;
+            }
         }
         var preparedElement = elementClass.prototype;
         // artificial constructor: call constructor() and copies members
@@ -300,4 +319,3 @@ function observe(observedProps) {
         };
     }
 }
-//# sourceMappingURL=polymer-ts.js.map

--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -165,15 +165,34 @@ module polymer {
       {
          var proto = elementClass.prototype;
          var instance = new (<any>elementClass)();
-         proto.is             = instance.is;
-         proto.extends        = instance.extends;
-         proto.properties     = instance.properties;
-         proto.listeners      = instance.listeners;
-         proto.observers      = instance.observers;
-         proto.behaviors      = instance.behaviors;
-         proto.hostAttributes = instance.hostAttributes;
-         proto.style          = instance.style;
-         proto.template       = instance.template;
+		 if (!instance.is) {
+			throw new Error("no name for " + elementClass);
+		 }
+         proto.is                = instance.is;
+		 if  (instance.extends) {
+			proto.extends        = instance.extends;
+		 }
+		 if  (instance.properties) {
+			proto.properties     = instance.properties;
+		 }
+		 if  (instance.listeners) {
+			proto.listeners      = instance.listeners;
+		 }
+		 if  (instance.observers) {
+			proto.observers      = instance.observers;
+		 }
+		 if  (instance.behaviors) {
+			proto.behaviors      = instance.behaviors;
+		 }
+		 if  (instance.hostAttributes) {
+			proto.hostAttributes = instance.hostAttributes;
+		 }
+		 if  (instance.style) {
+			proto.style          = instance.style;
+		 }
+		 if  (instance.template) {
+			proto.template       = instance.template;
+		 }
       }
       
       var preparedElement = elementClass.prototype;


### PR DESCRIPTION
There was a problem with the listeners, behavior etc properties copy in the TS1.4 compatibility part of polymer-ts.

Indeed, properties were copied despite the fact they could be undefined, thus adding properties to prototype but with undefined values. In Polymer 1.1.3, this caused Polymer not to set the default values for those properties (ex: behaviors was undefined) and crashed if attempt to register a component.

This PR fixes this issue, could you please review it and tell me it's ok for you?