### PR TITLE
Allow multiple calls to .register() on an element class.

### DIFF
--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -141,6 +141,7 @@ module polymer {
 
       // add a default create method()
       pb["register"]=function(dontRegister?: boolean) {
+         if(polymer.isRegistered(this)) return;
          if(dontRegister===true) polymer.createClass(this);
          else polymer.createElement(this);
       }


### PR DESCRIPTION
By allowing multiple calls to `.register()` for a given element class, it becomes possible for code that wants to use a particular element to ensure that it has been registered, without needing to coordinate with other code to avoid duplicate calls. Essentially, this makes the `.register()` call idempotent. Note that I have not updated the `.js` or minified files (see #37).
