### PR TITLE
property: readOnly is camel-cased

### DIFF
--- a/polymer-ts.ts
+++ b/polymer-ts.ts
@@ -112,7 +112,7 @@ module polymer {
       type?: any;
       value?: any;
       reflectToAttribute?: boolean;
-      readonly?: boolean;
+      readOnly?: boolean;
       notify?: boolean;
       computed?: string;
       observer?: string;


### PR DESCRIPTION
See: https://www.polymer-project.org/1.0/docs/devguide/properties.html

With a lowercase-only `readonly`, Polymer doesn't generate _set$name
setters for the property.