### PR TITLE
Declaring reliance on Polymer

### DIFF
--- a/polymer-ts.html
+++ b/polymer-ts.html
@@ -1,1 +1,3 @@
-﻿<script src="polymer-ts.js"></script>
+<link rel="import" href="../polymer/polymer.html">
+
+<script src="polymer-ts.js"></script>

--- a/polymer-ts.min.html
+++ b/polymer-ts.min.html
@@ -1,1 +1,2 @@
-﻿<script src="polymer-ts.min.js"></script>
+<link rel="import" href="../polymer/polymer.html">
+<script src="polymer-ts.min.js"></script>


### PR DESCRIPTION
I'm currently working on a project that enforces versioning of dependencies in applications using Web Components, and whilst developing this I've found that as dependencies are imported PolymerTS can sometimes be loaded before Polymer has loaded, causing it to throw errors, because it doesn't declare Polymer as a dependency in it's markup.

Adding this link ensures that PolymerTS is loaded after Polymer has been imported.